### PR TITLE
Fix registry bug affecting setup.py

### DIFF
--- a/lib/registry/mp1.py
+++ b/lib/registry/mp1.py
@@ -649,7 +649,7 @@ param       A dicitonary of keyword arguments are passed directly to the
             error[Ids] = y[Ids] - yy
             dx[Ids] = error[Ids] / yyx
             if verbose:
-                print x, yy, yyx, dx, Ids
+                print(x, yy, yyx, dx, Ids)
             x[Ids] += dx[Ids]
             # An out-of-bounds index
             IooB = np.logical_or( x < xmin, x > xmax)


### PR DESCRIPTION
Fix print() parentheses bug in mp1.py, which had caused setup.py to fail.