### PR TITLE
Alpha

### DIFF
--- a/lib/registry/mp1.py
+++ b/lib/registry/mp1.py
@@ -2304,7 +2304,7 @@ along with temperature.
             Isat[I] = np.logical_and( s[I]<=ssV, s[I]>=ssL )
             T[Isat] = Tsat[Isat]
             if quality:
-                x[Isat] = (s[Isat] - ssL)/(ssV-ssL)
+                x[Isat] = (s[Isat] - ssL[Isat])/(ssV[Isat]-ssL[Isat])
 
         # Isat is now a down-select array
         Isat = np.logical_not(Isat)
@@ -2408,7 +2408,7 @@ along with temperature.
             Isat[I] = np.logical_and( h[I]<=hsV, h[I]>=hsL )
             T[Isat] = Tsat[Isat]
             if quality:
-                x[Isat] = (h[Isat] - hsL)/(hsV-hsL)
+                x[Isat] = (h[Isat] - hsL[Isat])/(hsV[Isat]-hsL[Isat])
                 
         # Isat is now a down-select array
         Isat = np.logical_not(Isat)

--- a/lib/registry/mp1.py
+++ b/lib/registry/mp1.py
@@ -678,7 +678,7 @@ param       A dicitonary of keyword arguments are passed directly to the
             # An out-of-bounds index
             IooB = np.logical_or( x < xmin, x > xmax)
             count_oob = 0
-            while IooB.any():
+            while IooB[Ids].any():
                 dx[IooB] /= 2.
                 x[IooB] -= dx[IooB]
                 IooB = np.logical_or( x < xmin, x > xmax)

--- a/lib/registry/mp1.py
+++ b/lib/registry/mp1.py
@@ -2302,6 +2302,8 @@ along with temperature.
 
             # Finally, isolate points that are saturated
             Isat[I] = np.logical_and( s[I]<=ssV, s[I]>=ssL )
+            Ta[Isat] = Tsat[Isat]
+            Tb[Isat] = Tsat[Isat]
             T[Isat] = Tsat[Isat]
             if quality:
                 x[Isat] = (s[Isat] - ssL[Isat])/(ssV[Isat]-ssL[Isat])
@@ -2406,6 +2408,8 @@ along with temperature.
 
             # Finally, isolate points that are saturated
             Isat[I] = np.logical_and( h[I]<=hsV, h[I]>=hsL )
+            Ta[Isat] = Tsat[Isat]
+            Tb[Isat] = Tsat[Isat]
             T[Isat] = Tsat[Isat]
             if quality:
                 x[Isat] = (h[Isat] - hsL[Isat])/(hsV[Isat]-hsL[Isat])

--- a/steammp1test.py
+++ b/steammp1test.py
@@ -170,7 +170,7 @@ print(mp1obj.cv(T=600,d=1.8242))
 print(mp1obj.cv(T=424.98,x=0.5))
 print(mp1obj.cv(T=800,p=250))
 
-#T_s (has bugs)
+#T_s
 mp1obj.T_s(p=5,s=0.39295) 
 mp1obj.T_s(p=[5,5],s=0.39295)
 mp1obj.T_s(p=np.asarray(5),s=0.39295)
@@ -186,7 +186,7 @@ print(mp1obj.T_s(p=[5],s=7.5561))
 print(mp1obj.T_s(p=[5],s=4.3406,quality=True))
 print(mp1obj.T_s(p=[250],s=6.0867))
 
-#T_h (has bugs)
+#T_h
 mp1obj.T_h(p=5,h=113.02) 
 mp1obj.T_h(p=[5,5],h=113.02)
 mp1obj.T_h(p=np.asarray(5),h=113.02)
@@ -202,5 +202,18 @@ print(mp1obj.T_h(p=[5],h=3120.1))
 print(mp1obj.T_h(p=[5],h=1694.095,quality=True))
 print(mp1obj.T_h(p=[250],h=3262.2))
 
-# Performing computations at ref A
-#print(mp1obj.T(p=5,d=996.74)) #error
+#Error in T_s
+print('This Errors Out')
+print(mp1obj.T_s(p=5, s=5, quality=True)) #works, just mixture
+print(mp1obj.T_s(p=5, s=8, quality=True)) #works, just vapor
+print(mp1obj.T_s(p=5, s=[5,6], quality=True)) #works, array of s, just mixture
+#print(mp1obj.T_s(p=5, s=[5,8])) #error, array of s, both liq and vapor. #'iter1_() failed to produce a guess that was in-bounds'
+#print(mp1obj.T_s(p=5, s=[5,8],quality=True)) #Line 2307: ValueError: NumPy boolean array indexing assignment cannot assign 2 input values to the 1 output values where the mask is true
+
+#Same Error in T_h
+print('This Errors Out Too')
+print(mp1obj.T_h(p=5, h=1700, quality=True)) #works, just mixture
+print(mp1obj.T_h(p=5, h=4000, quality=True)) #works, just vapor
+print(mp1obj.T_h(p=5, h=[1700,1800], quality=True)) #works, array of h, just mixture
+#print(mp1obj.T_h(p=5, h=[1700,4000])) #error, array of s, both liq and vapor. #'iter1_() failed to produce a guess that was in-bounds'
+print(mp1obj.T_h(p=5, h=[1700,4000],quality=True)) #Line 2411: ValueError: NumPy boolean array indexing assignment cannot assign 2 input values to the 1 output values where the mask is true

--- a/steammp1test.py
+++ b/steammp1test.py
@@ -180,6 +180,11 @@ mp1obj.T_s(p=5,s=np.asarray(0.39295))
 mp1obj.T_s(p=np.asarray(5),s=np.asarray([0.39295,0.39295]))
 mp1obj.T_s(p=np.asarray(5),s=np.asarray(0.39295))
 mp1obj.T_s(p=np.asarray([5,5]),s=np.asarray([0.39295,0.39295]))
+mp1obj.T_s(p=5, s=5, quality=True)
+mp1obj.T_s(p=5, s=8, quality=True)
+mp1obj.T_s(p=5, s=[5,6], quality=True)
+mp1obj.T_s(p=5, s=[5,8])
+mp1obj.T_s(p=5, s=[5,8],quality=True)
 print('T_s')
 print(mp1obj.T_s(p=[5],s=0.39295))
 print(mp1obj.T_s(p=[5],s=7.5561))
@@ -196,24 +201,13 @@ mp1obj.T_h(p=5,h=np.asarray(113.02))
 mp1obj.T_h(p=np.asarray(5),h=np.asarray([113.02,113.02]))
 mp1obj.T_h(p=np.asarray(5),h=np.asarray(113.02))
 mp1obj.T_h(p=np.asarray([5,5]),h=np.asarray([113.02,113.02]))
+mp1obj.T_h(p=5, h=1700, quality=True)
+mp1obj.T_h(p=5, h=4000, quality=True)
+mp1obj.T_h(p=5, h=[1700,1800], quality=True)
+mp1obj.T_h(p=5, h=[1700,4000])
+mp1obj.T_h(p=5, h=[1700,4000],quality=True)
 print('T_h')
 print(mp1obj.T_h(p=[5],h=113.02))
 print(mp1obj.T_h(p=[5],h=3120.1))
 print(mp1obj.T_h(p=[5],h=1694.095,quality=True))
 print(mp1obj.T_h(p=[250],h=3262.2))
-
-#Error in T_s
-print('This Errors Out')
-print(mp1obj.T_s(p=5, s=5, quality=True)) #works, just mixture
-print(mp1obj.T_s(p=5, s=8, quality=True)) #works, just vapor
-print(mp1obj.T_s(p=5, s=[5,6], quality=True)) #works, array of s, just mixture
-#print(mp1obj.T_s(p=5, s=[5,8])) #error, array of s, both liq and vapor. #'iter1_() failed to produce a guess that was in-bounds'
-#print(mp1obj.T_s(p=5, s=[5,8],quality=True)) #Line 2307: ValueError: NumPy boolean array indexing assignment cannot assign 2 input values to the 1 output values where the mask is true
-
-#Same Error in T_h
-print('This Errors Out Too')
-print(mp1obj.T_h(p=5, h=1700, quality=True)) #works, just mixture
-print(mp1obj.T_h(p=5, h=4000, quality=True)) #works, just vapor
-print(mp1obj.T_h(p=5, h=[1700,1800], quality=True)) #works, array of h, just mixture
-#print(mp1obj.T_h(p=5, h=[1700,4000])) #error, array of s, both liq and vapor. #'iter1_() failed to produce a guess that was in-bounds'
-print(mp1obj.T_h(p=5, h=[1700,4000],quality=True)) #Line 2411: ValueError: NumPy boolean array indexing assignment cannot assign 2 input values to the 1 output values where the mask is true


### PR DESCRIPTION
I believe this should fix the problems with iter, and I can now generate plots like I'm used to. I don't think this fix is kludgy this time. It looks like it was just getting confused because there were no limits set on the saturated temperature iteration. So it ALWAYS came back that one index had a value that was out of bounds and made for insane results on the other index. 

After reflecting further, I put in one final commit that only has _iter1 check for out of bounds on the relevant Ids. I think this is a more comprehensive future proofing way to do things. You don't want to be checking if things are out of bounds for indexes that you're not changing, it just makes headaches.