### PR TITLE
Bracket error change

### DIFF
--- a/src/pyromat/registry/mp1.py
+++ b/src/pyromat/registry/mp1.py
@@ -1185,9 +1185,19 @@ param       A dicitonary of keyword arguments are passed directly to the
                 print(Iswap)
                 print("yb")
                 print(yy)
-            pm.utility.print_error('_HYBRID1: Failure to bracket a solution. Check function arguments to be sure they reference a valid state. This error usually occurs in inversion routines very close to the saturation line or if the properties are out-of-range.')
-            raise pm.utility.PMParamError('_HYBRID1: At least one max/min value does not bracket a solution!')
-        
+
+            bads = np.logical_not(np.logical_xor(Iswap[Ids], yy >= y[Ids]))
+            if bads.all():
+                pm.utility.print_warning(
+                    '_HYBRID1: Failure to bracket a solution. Check function arguments to be sure they reference a valid state. This error usually occurs in inversion routines very close to the saturation line or if the properties are out-of-range.')
+                raise pm.utility.PMParamError(
+                    '_HYBRID1: At least one max/min value does not bracket a solution!')
+            else:
+                Ids[bads] = np.logical_not(Ids[bads])
+                x[bads] = np.nan
+                pm.utility.print_warning(
+                    '_HYBRID1: Failure to bracket a solution for some points. Values set to np.nan. Check function arguments to be sure they reference a valid state. This error usually occurs in inversion routines very close to the saturation line or if the properties are out-of-range.')
+
         # Calculate the thrid candidate solution
         xc[Ids] = 0.5*(xmin[Ids] + xmax[Ids])
         

--- a/src/pyromat/registry/mp1.py
+++ b/src/pyromat/registry/mp1.py
@@ -1198,7 +1198,7 @@ param       A dicitonary of keyword arguments are passed directly to the
                 Ids[bads] = np.logical_not(Ids[bads])
                 x[bads] = np.nan
                 pm.utility.print_warning(
-                    '_HYBRID1: Failure to bracket a solution for input element(s): {}. Values set to np.nan. Check function arguments to be sure they reference a valid state. This error usually occurs in inversion routines very close to the saturation line or if the properties are out-of-range.'.format(np.array(np.where(bads)).flatten()))
+                    '_HYBRID1: Failure to bracket a solution for input element(s): {}. Values set to np.nan. Check function arguments to be sure they reference a valid state. This error usually occurs in inversion routines very close to the saturation line or if the properties are out-of-range.'.format(np.flatnonzero(bads)))
 
         # Calculate the thrid candidate solution
         xc[Ids] = 0.5*(xmin[Ids] + xmax[Ids])

--- a/src/pyromat/registry/mp1.py
+++ b/src/pyromat/registry/mp1.py
@@ -1186,17 +1186,19 @@ param       A dicitonary of keyword arguments are passed directly to the
                 print("yb")
                 print(yy)
 
+            # Which points failed?
             bads = np.logical_not(np.logical_xor(Iswap[Ids], yy >= y[Ids]))
-            if bads.all():
+            if bads.all():  # All points failed to bracket. Fail and raise Error.
                 pm.utility.print_warning(
                     '_HYBRID1: Failure to bracket a solution. Check function arguments to be sure they reference a valid state. This error usually occurs in inversion routines very close to the saturation line or if the properties are out-of-range.')
                 raise pm.utility.PMParamError(
-                    '_HYBRID1: At least one max/min value does not bracket a solution!')
-            else:
+                    '_HYBRID1: None of the supplied values bracket a solution!')
+            else:  # Only some have failed to bracket
+                # Don't continue for failed points
                 Ids[bads] = np.logical_not(Ids[bads])
                 x[bads] = np.nan
                 pm.utility.print_warning(
-                    '_HYBRID1: Failure to bracket a solution for some points. Values set to np.nan. Check function arguments to be sure they reference a valid state. This error usually occurs in inversion routines very close to the saturation line or if the properties are out-of-range.')
+                    '_HYBRID1: Failure to bracket a solution for input element(s): {}. Values set to np.nan. Check function arguments to be sure they reference a valid state. This error usually occurs in inversion routines very close to the saturation line or if the properties are out-of-range.'.format(np.array(np.where(bads)).flatten()))
 
         # Calculate the thrid candidate solution
         xc[Ids] = 0.5*(xmin[Ids] + xmax[Ids])


### PR DESCRIPTION
Here's the proposal to changing how the bracketing in _hybrid1 throws an error that you asked to look at. Returns np.nan and completes the calculation for other points in an array when a small number of points fail.

Can consider the following code sample to see what's different:

```
import pyromat as pm

h2o = pm.get('mp.H2O')

T = h2o.T_h(p=[200, 200, 2000], h=[400, 4400, 4400])
print(T)
print(h2o.T_h(p=[200], h=[400, 4400]))
```