### PR TITLE
Fix an observed bug within mp1.hsd - fixes Issue #32

### DIFF
--- a/src/pyromat/registry/mp1.py
+++ b/src/pyromat/registry/mp1.py
@@ -3077,8 +3077,8 @@ methods independently.
             tt = Tscale / T
             dd = d2 / dscale
             a,at,ad,_,_,_ = self._ar(tt,dd,1)
-            h[I] += (dd*ad + tt*at)*x[I]
-            s[I] += (tt*at - a)*x[I]
+            h[I] += (dd[I]*ad[I] + tt[I]*at[I])*x[I]
+            s[I] += (tt[I]*at[I] - a[I])*x[I]
             # Modify density
             d1[I] = temp/d1[I] 
             d1[I] += x[I]/d2[I]


### PR DESCRIPTION
Regarding Issue #32 

Corrects a crash in mp1.hsd() that is caused by some points under the steam dome and some points outside. Just an issue where not all subarrays are sliced by the under-the-dome indices for the calculation.