### PR TITLE
Modifications in response to issue #52 to go back to original call si…

### DIFF
--- a/src/pyromat/registry/ig.py
+++ b/src/pyromat/registry/ig.py
@@ -1776,7 +1776,7 @@ T, p, d, v, e, h, and s.
 
 
 
-    def T_s(self,s,*varg, **kwarg):
+    def T_s(self,s,p=None, **kwarg):
         """Temperature as a function of entropy
 ** Depreciated - use T() **
         
@@ -1789,17 +1789,12 @@ Accepts unit_energy / unit_matter / unit_temperature
         unit_matter / unit_volume
 Returns unit_temperature
 """
-        if len(varg) > 0:
-            if 'p' in kwarg:
-                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
-            kwarg['p'] = varg[0]
-        if len(varg) > 1:
-            raise pm.utility.PMParamError('There are only two positional arguments: s, p.')
-
+        if p is not None:
+            return self.T(s=s, p=p)
         return self.T(s=s, **kwarg)
 
 
-    def T_h(self,h,*varg,**kwarg):
+    def T_h(self,h,p=None,**kwarg):
         """Temperature as a function of enthalpy
 ** Depreciated - use T() **
 
@@ -1815,13 +1810,8 @@ Accepts unit_energy / unit_matter / unit_temperature
         unit_pressure
 Returns unit_temperature
 """
-        if len(varg) > 0:
-            if 'p' in kwarg:
-                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
-            kwarg['p'] = varg[0]
-        if len(varg) > 1:
-            raise pm.utility.PMParamError('There are only two positional arguments: h, p.')
-
+        if p is not None:
+            return self.T(h=h, p=p)
         return self.T(h=h, **kwarg)
 
 

--- a/src/pyromat/registry/ig.py
+++ b/src/pyromat/registry/ig.py
@@ -1783,15 +1783,20 @@ T, p, d, v, e, h, and s.
     T = T_s(s)
         or
     T = T_s(s,p)
-        or
-    T = T_s(s,d)
 
 Accepts unit_energy / unit_matter / unit_temperature
         unit_pressure
         unit_matter / unit_volume
 Returns unit_temperature
 """
-        return self.T(*varg, s=s, **kwarg)
+        if len(varg) > 0:
+            if 'p' in kwarg:
+                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
+            kwarg['p'] = varg[0]
+        if len(varg) > 1:
+            raise pm.utility.PMParamError('There are only two positional arguments: s, p.')
+
+        return self.T(s=s, **kwarg)
 
 
     def T_h(self,h,*varg,**kwarg):
@@ -1810,8 +1815,14 @@ Accepts unit_energy / unit_matter / unit_temperature
         unit_pressure
 Returns unit_temperature
 """
-        # Convert the 
-        return self.T(*varg, h=h, **kwarg)
+        if len(varg) > 0:
+            if 'p' in kwarg:
+                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
+            kwarg['p'] = varg[0]
+        if len(varg) > 1:
+            raise pm.utility.PMParamError('There are only two positional arguments: h, p.')
+
+        return self.T(h=h, **kwarg)
 
 
     def p_s(self,s,*varg, **kwarg):

--- a/src/pyromat/registry/ig2.py
+++ b/src/pyromat/registry/ig2.py
@@ -1245,7 +1245,7 @@ T, p, d, v, e, h, and s.
         return out
 
 
-    def T_s(self,s,*varg, **kwarg):
+    def T_s(self,s,p=None, **kwarg):
         """Temperature as a function of entropy
 ** Depreciated - use T() **
         
@@ -1258,17 +1258,12 @@ Accepts unit_energy / unit_matter / unit_temperature
         unit_matter / unit_volume
 Returns unit_temperature
 """
-        if len(varg) > 0:
-            if 'p' in kwarg:
-                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
-            kwarg['p'] = varg[0]
-        if len(varg) > 1:
-            raise pm.utility.PMParamError('There are only two positional arguments: s, p.')
-
+        if p is not None:
+            return self.T(s=s, p=p)
         return self.T(s=s, **kwarg)
 
 
-    def T_h(self,h,*varg,**kwarg):
+    def T_h(self,h,p=None,**kwarg):
         """Temperature as a function of enthalpy
 ** Depreciated - use T() **
 
@@ -1284,15 +1279,8 @@ Accepts unit_energy / unit_matter / unit_temperature
         unit_pressure
 Returns unit_temperature
 """
-        if len(varg) > 0:
-            if 'p' in kwarg:
-                raise pm.utility.PMParamError(
-                    'p was specified both positionally and with a keyword.')
-            kwarg['p'] = varg[0]
-        if len(varg) > 1:
-            raise pm.utility.PMParamError(
-                'There are only two positional arguments: h, p.')
-
+        if p is not None:
+            return self.T(h=h, p=p)
         return self.T(h=h, **kwarg)
 
 

--- a/src/pyromat/registry/ig2.py
+++ b/src/pyromat/registry/ig2.py
@@ -1249,18 +1249,23 @@ T, p, d, v, e, h, and s.
         """Temperature as a function of entropy
 ** Depreciated - use T() **
         
-    T = T_s(s)
+   T = T_s(s)
         or
     T = T_s(s,p)
-        or
-    T = T_s(s,d)
 
 Accepts unit_energy / unit_matter / unit_temperature
         unit_pressure
         unit_matter / unit_volume
 Returns unit_temperature
 """
-        return self.T(*varg, s=s, **kwarg)
+        if len(varg) > 0:
+            if 'p' in kwarg:
+                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
+            kwarg['p'] = varg[0]
+        if len(varg) > 1:
+            raise pm.utility.PMParamError('There are only two positional arguments: s, p.')
+
+        return self.T(s=s, **kwarg)
 
 
     def T_h(self,h,*varg,**kwarg):
@@ -1279,8 +1284,16 @@ Accepts unit_energy / unit_matter / unit_temperature
         unit_pressure
 Returns unit_temperature
 """
-        # Convert the 
-        return self.T(*varg, h=h, **kwarg)
+        if len(varg) > 0:
+            if 'p' in kwarg:
+                raise pm.utility.PMParamError(
+                    'p was specified both positionally and with a keyword.')
+            kwarg['p'] = varg[0]
+        if len(varg) > 1:
+            raise pm.utility.PMParamError(
+                'There are only two positional arguments: h, p.')
+
+        return self.T(h=h, **kwarg)
 
 
     def p_s(self,s,*varg, **kwarg):

--- a/src/pyromat/registry/igmix.py
+++ b/src/pyromat/registry/igmix.py
@@ -1038,15 +1038,20 @@ in the mixture."""
     T = T_s(s)
         or
     T = T_s(s,p)
-        or
-    T = T_s(s,d)
 
 Accepts unit_energy / unit_matter / unit_temperature
         unit_pressure
         unit_matter / unit_volume
 Returns unit_temperature
 """
-        return self.T(s=s, *varg, **kwarg)
+        if len(varg) > 0:
+            if 'p' in kwarg:
+                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
+            kwarg['p'] = varg[0]
+        if len(varg) > 1:
+            raise pm.utility.PMParamError('There are only two positional arguments: s, p.')
+
+        return self.T(s=s, **kwarg)
 
 
     def T_h(self,h, *varg, **kwarg):
@@ -1062,7 +1067,15 @@ Accepts unit_energy / unit_matter
         unit_pressure
 Returns unit_temperature
 """
-        return self.T(h=h, *varg, **kwarg)
+        if len(varg) > 0:
+            if 'p' in kwarg:
+                raise pm.utility.PMParamError(
+                    'p was specified both positionally and with a keyword.')
+            kwarg['p'] = varg[0]
+        if len(varg) > 1:
+            raise pm.utility.PMParamError('There are only two positional arguments: h, p.')
+
+        return self.T(h=h, **kwarg)
         
         
     def p_s(self, s, *varg, **kwarg):

--- a/src/pyromat/registry/igmix.py
+++ b/src/pyromat/registry/igmix.py
@@ -1032,7 +1032,7 @@ in the mixture."""
         return self._y.copy()
 
 
-    def T_s(self,s,*varg,**kwarg):
+    def T_s(self,s,p=None,**kwarg):
         """Temperature as a function of entropy
 ** Depreciated - use T() **
     T = T_s(s)
@@ -1044,17 +1044,12 @@ Accepts unit_energy / unit_matter / unit_temperature
         unit_matter / unit_volume
 Returns unit_temperature
 """
-        if len(varg) > 0:
-            if 'p' in kwarg:
-                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
-            kwarg['p'] = varg[0]
-        if len(varg) > 1:
-            raise pm.utility.PMParamError('There are only two positional arguments: s, p.')
-
+        if p is not None:
+            return self.T(s=s, p=p)
         return self.T(s=s, **kwarg)
 
 
-    def T_h(self,h, *varg, **kwarg):
+    def T_h(self,h, p=None, **kwarg):
         """Temperature as a function of enthalpy
 ** Depreciated - use T() **
     T = T_h(h)
@@ -1067,14 +1062,8 @@ Accepts unit_energy / unit_matter
         unit_pressure
 Returns unit_temperature
 """
-        if len(varg) > 0:
-            if 'p' in kwarg:
-                raise pm.utility.PMParamError(
-                    'p was specified both positionally and with a keyword.')
-            kwarg['p'] = varg[0]
-        if len(varg) > 1:
-            raise pm.utility.PMParamError('There are only two positional arguments: h, p.')
-
+        if p is not None:
+            return self.T(h=h, p=p)
         return self.T(h=h, **kwarg)
         
         

--- a/src/pyromat/registry/mp1.py
+++ b/src/pyromat/registry/mp1.py
@@ -4138,7 +4138,7 @@ Returns specific heat ratio, which is dimensionless
         return cp/cv
 
 
-    def T_s(self, s, *varg, quality=False, **kwarg):
+    def T_s(self, s, p=None, quality=False, **kwarg):
         """Temperature from entropy
 ** Depreciated - use T() **
 
@@ -4154,14 +4154,10 @@ along with temperature.
 
     T,x = T_s(s, p=p, quality=True)
 """
-        if len(varg) > 0:
-            if 'p' in kwarg:
-                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
-            kwarg['p'] = varg[0]
-        if len(varg) > 1:
-            raise pm.utility.PMParamError('There are only two positional arguments: s, p.')
-
-        T,_,_,x,_ = self._argparse(s=s, **kwarg)
+        if p is not None:
+            T,_,_,x,_ = self._argparse(s=s, p=p)
+        else:
+            T,_,_,x,_ = self._argparse(s=s, **kwarg)
         if quality:
             return T,x
         return T
@@ -4189,7 +4185,7 @@ with pressure.
 
 
 
-    def T_h(self, h, *varg, quality=False, **kwarg):
+    def T_h(self, h, p=None, quality=False, **kwarg):
         """Temperature from entropy
 ** Depreciated - use T() **
 
@@ -4205,15 +4201,10 @@ along with temperature.
 
     T,x = T_s(s, p=p, quality=True)
 """
-        if len(varg) > 0:
-            if 'p' in kwarg:
-                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
-            kwarg['p'] = varg[0]
-        if len(varg) > 1:
-            raise pm.utility.PMParamError('There are only two positional arguments: h, p.')
-
-        T,_,_,x,_ = self._argparse(h=h, **kwarg)
-        
+        if p is not None:
+            T,_,_,x,_ = self._argparse(h=h, p=p)
+        else:
+            T,_,_,x,_ = self._argparse(h=h, **kwarg)
         if quality:
             return T,x
         return T

--- a/src/pyromat/registry/mp1.py
+++ b/src/pyromat/registry/mp1.py
@@ -4154,7 +4154,14 @@ along with temperature.
 
     T,x = T_s(s, p=p, quality=True)
 """
-        T,_,_,x,_ = self._argparse(*varg, s=s, **kwarg)
+        if len(varg) > 0:
+            if 'p' in kwarg:
+                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
+            kwarg['p'] = varg[0]
+        if len(varg) > 1:
+            raise pm.utility.PMParamError('There are only two positional arguments: s, p.')
+
+        T,_,_,x,_ = self._argparse(s=s, **kwarg)
         if quality:
             return T,x
         return T
@@ -4198,7 +4205,14 @@ along with temperature.
 
     T,x = T_s(s, p=p, quality=True)
 """
-        T,_,_,x,_ = self._argparse(*varg, h=h, **kwarg)
+        if len(varg) > 0:
+            if 'p' in kwarg:
+                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
+            kwarg['p'] = varg[0]
+        if len(varg) > 1:
+            raise pm.utility.PMParamError('There are only two positional arguments: h, p.')
+
+        T,_,_,x,_ = self._argparse(h=h, **kwarg)
         
         if quality:
             return T,x


### PR DESCRIPTION
closes #52. Modifications were made as simply as possible and used a similar method to argparse. 

Check for the presence of the variable of interest in `vargs`, and if it's there, move it into `kwargs`. Then call the followup function without referencing `vargs`. Only applies when `p` is the first positional argument, because `argparse` already assumes `T` is the first positional argument.
```
        if len(varg) > 0:
            if 'p' in kwarg:
                raise pm.utility.PMParamError('p was specified both positionally and with a keyword.')
            kwarg['p'] = varg[0]
        if len(varg) > 1:
            raise pm.utility.PMParamError('There are only two positional arguments: h, p.')
```

Some test code to ensure reliability. Any other calls already rely on kwargs and should be fine. 

```
def test_bug_git52(self):
        # ig, ig2, igmix, mp1
        subs = [pm.get("ig.BH3O3"), pm.get("ig.O2"), pm.get('ig.air'), pm.get('mp.H2O')]

        for sub in subs:
            p = 1
            T = 500
            h = sub.h(T=T, p=p)
            s = sub.s(T=T, p=p)
            assert sub.T_s(s, p) == approx(sub.T_s(s, p=p))
            assert sub.T_s(s, p) == approx(sub.T_s(s=s, p=p))
            assert sub.T_h(h, p) == approx(sub.T_h(h, p=p))
            assert sub.T_h(h, p) == approx(sub.T_h(h=h, p=p))
            if hasattr(sub, "p_s"):
                assert sub.p_s(s, T) == approx(sub.p_s(s, T=T))
                assert sub.p_s(s, T) == approx(sub.p_s(s=s, T=T))
            if hasattr(sub, "d_s"):
                assert sub.d_s(s, T) == approx(sub.d_s(s, T=T))
                assert sub.d_s(s, T) == approx(sub.d_s(s=s, T=T))

```