### PR TITLE
Add CI tests based on the straightforward ig and mp1 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: [ "addtests-joss" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "addtests-joss" ]
+    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: test
+
+on:
+  push:
+    branches: [ "addtests-joss" ]
+  pull_request:
+    branches: [ "addtests-joss" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        python setup.py install
+    - name: Test Ideal Gases
+      working-directory: ./src/test
+      run: pytest test_ig.py
+    - name: Test Multiphase
+      working-directory: ./src/test
+      run: pytest test_mp1.py

--- a/src/test/test_ig.py
+++ b/src/test/test_ig.py
@@ -1,0 +1,565 @@
+import pyromat as pm
+import numpy as np
+from pytest import approx, raises
+import pytest
+
+
+class TestInputErrors:
+    @pytest.fixture(params=('ig.O2', 'ig.BH3O3', 'ig.air'),
+                    ids=('oxygen-ig2', 'BH3O3-ig', 'air-ig'))
+    def gas(self, request):
+        o = pm.get(request.param)
+        return o
+
+    def test_T_only_varg(self, gas):
+        # Based on how .T is written, it interprets this as a temperature given
+        # So just make sure that works
+        assert gas.T(300) == gas.T(T=300, p=pm.config['def_p'])
+
+    def test_T_double_specified(self, gas):
+        with raises(pm.utility.PMParamError):
+            gas.T(300, T=300)
+
+    def test_p_double_specified(self, gas):
+        with raises(pm.utility.PMParamError):
+            gas.T(300, 1, p=1)
+
+    def test_varg_specified(self, gas):
+        assert gas.s(300, 1) == gas.s(p=1, T=300)
+
+    def test_varg_toomany(self, gas):
+        with raises(pm.utility.PMParamError):
+            gas.T(300, 1, 5)
+
+    def test_any_arg_toomany(self, gas):
+        with raises(pm.utility.PMParamError):
+            gas.T(300, 1, s=5)
+        with raises(pm.utility.PMParamError):
+            gas.T(T=300, p=1, s=5)
+
+    def test_default_usage(self, gas):
+        assert gas.s() == gas.s(T=pm.config['def_T'], p=pm.config['def_p'])
+        assert gas.s(T=pm.config['def_T']) == gas.s(T=pm.config['def_T'], p=pm.config['def_p'])
+        assert gas.s(p=pm.config['def_p']) == gas.s(T=pm.config['def_T'], p=pm.config['def_p'])
+
+    def test_invarg_toomany(self, gas):
+        with raises(pm.utility.PMParamError):
+            gas.T(h=300, s=5)
+        with raises(pm.utility.PMParamError):
+            gas.T(e=300, s=5)
+
+    def test_d_v_collision(self, gas):
+        with raises(pm.utility.PMParamError):
+            gas.T(d=1, v=1)
+
+    def test_illegal_prop(self, gas):
+        with raises(pm.utility.PMParamError):
+            gas.T(T=300, fakeprop=10000)
+
+    def test_T_oob_all(self, gas):
+        with raises(pm.utility.PMParamError):
+            gas.T(T=30000, p=1)
+
+    def test_T_oob_some(self, gas):
+        vals = gas.T(T=[300, 30000], p=1)
+        assert vals[0] == 300
+        assert np.isnan(vals[1])
+
+
+class TestGeneral:
+
+    @pytest.mark.parametrize('sub', ('ig.O2', 'ig.BH3O3', 'ig.air'), ids=('oxygen-ig2', 'boric acid-ig', 'air-ig'))
+    def test_get(self, sub):
+        # Just confirm no error
+        igobj = pm.get(sub)
+
+    @ pytest.mark.parametrize('gas, expect', [('ig.O2',(200, 6000)), ('ig.BH3O3',(298, 6000)), ('ig.air',(200, 6000))])
+    def test_Tlim(self, gas, expect):
+        assert pm.get(gas).Tlim() == approx(expect)
+
+    @ pytest.mark.parametrize('gas, expect', [('ig.O2', 31.9988), ('ig.BH3O3', 61.833), ('ig.air', 28.96493)])
+    def test_mw(self, gas, expect):
+        assert pm.get(gas).mw() == approx(expect)
+
+    @pytest.mark.parametrize('gas, expect', [('ig.O2', pm.units.const_Ru/31.9988), ('ig.BH3O3', pm.units.const_Ru/61.833), ('ig.air', pm.units.const_Ru/28.96493)])
+    def test_R(self, gas, expect):
+        assert pm.get(gas).R() == approx(expect)
+
+    @pytest.mark.parametrize('gas, expect', [
+        ('ig.O2', {'O': 2}),
+        ('ig.BH3O3', {'B': 1, 'H': 3, 'O': 3}),
+        ('ig.air', {'Ar': 0.009350187003740077, 'C': 0.00031400628012560254, 'O': 0.4195883917678354, 'N': 1.5617112342246846})
+    ])
+    def test_atoms(self, gas, expect):
+        assert pm.get(gas).atoms() == approx(expect)
+
+    @pytest.mark.parametrize('gas, expect', [
+        ('ig.air', {'ig.Ar': 0.009350187003740077, 'ig.CO2': 0.00031400628012560254, 'ig.N2': 0.7808556171123423, 'ig.O2': 0.2094801896037921})
+    ])
+    def test_X(self, gas, expect):
+        assert pm.get(gas).X() == approx(expect)
+
+    @pytest.mark.parametrize('gas, expect', [
+        ('ig.air', {'ig.Ar': 0.012895634840195168, 'ig.CO2': 0.0004771062632750561, 'ig.N2': 0.7552055804206431, 'ig.O2': 0.23142167847588652})
+    ])
+    def test_Y(self, gas, expect):
+        assert pm.get(gas).Y() == approx(expect)
+
+def complete_props_theory(propdict, subid):
+    """
+    Fill in some properties based on theoretical Ideal Gas values
+    """
+    sub = pm.get(subid)
+
+    newdict = propdict.copy()
+
+    newdict['d'] = newdict['p'] * 1e5 / (sub.R() * 1000 * newdict['T'])
+    newdict['v'] = 1/newdict['d']
+    newdict['e'] = newdict['h'] - sub.R()*newdict['T']
+    newdict['cv'] = newdict['cp'] - sub.R()
+    newdict['gam'] = newdict['cp']/newdict['cv']
+
+    return newdict
+
+
+def make_props_array(refs, subid):
+    """
+    Take a property array formatted like refs{}
+    """
+    propkeys = None
+    myrefs = []
+
+    # Find which ref states match this substance
+    for refkey in refs:
+        if refs[refkey]['sub'] == subid:
+            myrefs.append(refs[refkey])
+            if propkeys is None:
+                propkeys = refs[refkey]['props']
+
+    # Build a new dict from the refs
+    newdict= {
+        'props': {
+            key: [ref['props'][key] for ref in myrefs] for key in propkeys
+        },
+        'sub': subid,
+        'comment': 'multi'
+    }
+    return newdict
+
+
+# Four reference points for oxygen computed using pyromat, due to variability
+# of reference states.
+# Note that specific volumes are computed as 1/d for accuracy.
+refs = {}
+refs["oxygen_a"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 300,  # K
+        'p': 1,  # bar
+        'h': 1.69877563,  # kJ/kg
+        's': 6.41680485,  # kJ/kg K
+        'cp': 0.91841166  # kJ/kg K
+    },
+    'sub': 'ig.O2',
+    'comment': 'Room Temp and Pressure'
+}
+refs['oxygen_a']['props'] = complete_props_theory(refs['oxygen_a']['props'], refs['oxygen_a']['sub'])
+
+refs["oxygen_b"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 800,  # K
+        'p': 1,  # bar
+        'h': 494.96011806,  # kJ/kg
+        's': 7.37301205,  # kJ/kg K
+        'cp': 1.05471624  # kJ/kg K
+    },
+    'sub': 'ig.O2',
+    'comment': 'Increased Temp, Room Pressure'
+}
+refs['oxygen_b']['props'] = complete_props_theory(refs['oxygen_b']['props'], refs['oxygen_b']['sub'])
+
+refs["oxygen_c"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 900,  # K
+        'p': 1*(900/800)**(1.32282754/(1.32282754-1)),  # bar, gamma of 850K = 1.32282754
+        'h': 601.41481211,  # kJ/kg
+        's': 7.37301205,  # kJ/kg K
+        'cp': 1.07371185  # kJ/kg K
+    },
+    'sub': 'ig.O2',
+    'comment': 'Isentropic from state b'
+}
+refs['oxygen_c']['props'] = complete_props_theory(refs['oxygen_c']['props'], refs['oxygen_c']['sub'])
+
+refs["oxygen_d"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 1800,  # K
+        'p': 1000,  # bar
+        'h': 1614.04575249,  # kJ/kg
+        's': 6.47977787,  # kJ/kg K
+        'cp': 1.16705079  # kJ/kg K
+    },
+    'sub': 'ig.O2',
+    'comment': 'High T & P'
+}
+refs['oxygen_d']['props'] = complete_props_theory(refs['oxygen_d']['props'], refs['oxygen_c']['sub'])
+
+# Array
+refs['oxygen_array'] = make_props_array(refs, refs['oxygen_a']['sub'])
+
+
+refs["boricacid_a"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 300,  # K
+        'p': 1,  # bar
+        'h': -16045.78193466,  # kJ/kg
+        's': 4.78111299,  # kJ/kg K
+        'cp': 1.05979064  # kJ/kg K
+    },
+    'sub': 'ig.BH3O3',
+    'comment': 'Room Temp and Pressure'
+}
+refs['boricacid_a']['props'] = complete_props_theory(refs['boricacid_a']['props'], refs['boricacid_a']['sub'])
+
+refs["boricacid_b"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 800,  # K
+        'p': 1,  # bar
+        'h': -15328.26168563,  # kJ/kg
+        's': 6.13679451,  # kJ/kg K
+        'cp': 1.70773773  # kJ/kg K
+    },
+    'sub': 'ig.BH3O3',
+    'comment': 'Increased Temp, Room Pressure'
+}
+refs['boricacid_b']['props'] = complete_props_theory(refs['boricacid_b']['props'], refs['boricacid_b']['sub'])
+
+refs["boricacid_c"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 900,  # K
+        'p': 1*(900/800)**(1.08349905/(1.08349905-1)),  # bar, gamma of 850K = 1.08349905
+        'h': -15153.82697422,  # kJ/kg
+        's': 6.13679451,  # kJ/kg K
+        'cp': 1.7789004  # kJ/kg K
+    },
+    'sub': 'ig.BH3O3',
+    'comment': 'Isentropic from state b'
+}
+refs['boricacid_c']['props'] = complete_props_theory(refs['boricacid_c']['props'], refs['boricacid_c']['sub'])
+
+refs["boricacid_d"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 1800,  # K
+        'p': 1000,  # bar
+        'h': -13367.19402821,  # kJ/kg
+        's': 6.77542321,  # kJ/kg K
+        'cp': 2.12425583  # kJ/kg K
+    },
+    'sub': 'ig.BH3O3',
+    'comment': 'High T & P'
+}
+refs['boricacid_d']['props'] = complete_props_theory(refs['boricacid_d']['props'], refs['boricacid_d']['sub'])
+
+# Array
+refs['boricacid_array'] = make_props_array(refs, refs['boricacid_a']['sub'])
+
+
+refs["air_a"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 300,  # K
+        'p': 1,  # bar
+        'h': -2.4071345,  # kJ/kg
+        's': 6.7077026,  # kJ/kg K
+        'cp': 1.00483493  # kJ/kg K
+    },
+    'sub': 'ig.air',
+    'comment': 'Room Temp and Pressure'
+}
+refs['air_a']['props'] = complete_props_theory(refs['air_a']['props'], refs['air_a']['sub'])
+
+refs["air_b"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 800,  # K
+        'p': 1,  # bar
+        'h': 519.47733875,  # kJ/kg
+        's': 7.72402011,  # kJ/kg K
+        'cp': 1.09862262  # kJ/kg K
+    },
+    'sub': 'ig.air',
+    'comment': 'Increased Temp, Room Pressure'
+}
+refs['air_b']['props'] = complete_props_theory(refs['air_b']['props'], refs['air_b']['sub'])
+
+refs["air_c"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 900,  # K
+        'p': 1*(900/800)**(1.34859507/(1.34859507-1)),  # bar, gamma of 850K = 1.34859507
+        'h': 630.51678945,  # kJ/kg
+        's': 7.72397993,  # kJ/kg K
+        'cp': 1.12170972  # kJ/kg K
+    },
+    'sub': 'ig.air',
+    'comment': 'Isentropic from state b'
+}
+refs['air_c']['props'] = complete_props_theory(refs['air_c']['props'], refs['air_c']['sub'])
+
+refs["air_d"] = {
+    'props': {
+        # values generated by pyromat using T&p
+        'T': 1800,  # K
+        'p': 1000,  # bar
+        'h': 1699.26825827,  # kJ/kg
+        's': 6.69042738,  # kJ/kg K
+        'cp': 1.23698868  # kJ/kg K
+    },
+    'sub': 'ig.air',
+    'comment': 'High T & P'
+}
+refs['air_d']['props'] = complete_props_theory(refs['air_d']['props'], refs['air_d']['sub'])
+
+# Array
+refs['air_array'] = make_props_array(refs, refs['air_a']['sub'])
+
+
+class TestRefs:
+
+    @pytest.fixture(params=(refs[key] for key in refs), ids=(refs.keys()))
+    def refdat(self, request):
+        return {'sub': pm.get(request.param['sub']),
+                'data': request.param['props']}
+
+    @pytest.fixture(params=('p', 'T', 'd', 'v', 'e', 'h', 's', 'cp', 'cv', 'gam'))
+    def param(self, request):
+        return request.param
+
+    def test_pT(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], T=ref['T']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_pd(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], d=ref['d']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_pv(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], v=ref['v']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_Td(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(T=ref['T'], d=ref['d']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_Tv(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(T=ref['T'], v=ref['v']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_ps(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], s=ref['s']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_Ts(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(T=ref['T'], s=ref['s']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_ds(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(d=ref['d'], s=ref['s']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_vs(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(v=ref['v'], s=ref['s']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_ph(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], h=ref['h']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_dh(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(d=ref['d'], h=ref['h']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_vh(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(v=ref['v'], h=ref['h']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_pe(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], e=ref['e']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_de(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(d=ref['d'], e=ref['e']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    def test_ve(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(v=ref['v'], e=ref['e']) == approx(ref[param], rel=1e-5, abs=1e-1)
+
+    # Always Unsupported Cases
+    def test_Th(self, param, refdat):  # Can't work for ideal gases
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            fn(T=ref['T'], h=ref['h'])
+
+    def test_Te(self, param, refdat):  # Can't work for ideal gases
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            fn(T=ref['T'], e=ref['e'])
+
+    def test_dv(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            fn(d=ref['d'], v=ref['v'])
+
+    def test_hs(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            fn(h=ref['h'], s=ref['s'])
+
+    def test_es(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            fn(e=ref['e'], s=ref['s'])
+
+    def test_he(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            fn(h=ref['h'], e=ref['e'])
+
+    # Legacy (deprecated) functions
+    def test_T_s(self, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        assert sub.T_s(s=ref['s'], p=ref['p']) == approx(ref['T'], rel=1e-5, abs=1e-1)
+
+    def test_T_h(self, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        assert sub.T_h(h=ref['h']) == approx(ref['T'], rel=1e-5, abs=1e-1)
+
+    def test_p_s(self, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        assert sub.p_s(s=ref['s'], T=ref['T']) == approx(ref['p'], rel=1e-5, abs=1e-1)
+
+
+class TestState:
+
+    @pytest.fixture(params=(refs[key] for key in refs), ids=(refs.keys()))
+    def refdat(self, request):
+        return {'sub': pm.get(request.param['sub']),
+                'data': request.param['props']}
+
+    @pytest.fixture(params=('p', 'T', 'd', 'v', 'e', 'h', 's', 'cp', 'cv', 'gam'))
+    def prop(self, request):
+        return request.param
+
+    def test_state_pT(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(T=ref['T'], p=ref['p'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_pd(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], d=ref['d'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_pv(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], v=ref['v'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_Td(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(T=ref['T'], d=ref['d'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_Tv(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(T=ref['T'], v=ref['v'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_ps(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], s=ref['s'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_Ts(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(T=ref['T'], s=ref['s'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_ds(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(d=ref['d'], s=ref['s'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_vs(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(v=ref['v'], s=ref['s'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_ph(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], h=ref['h'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_Th(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        with raises(pm.utility.PMParamError):
+            state = sub.state(T=ref['T'], h=ref['h'])
+
+    def test_state_dh(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(d=ref['d'], h=ref['h'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_vh(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(v=ref['v'], h=ref['h'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_pe(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], e=ref['e'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_Te(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        with raises(pm.utility.PMParamError):
+            state = sub.state(T=ref['T'], e=ref['e'])
+
+    def test_state_de(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(d=ref['d'], e=ref['e'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)
+
+    def test_state_ve(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(v=ref['v'], e=ref['e'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-1)

--- a/src/test/test_mp1.py
+++ b/src/test/test_mp1.py
@@ -1,0 +1,875 @@
+import pyromat as pm
+import numpy as np
+from pytest import approx, raises
+import pytest
+
+
+class TestInputErrors:
+    @pytest.fixture(params=('mp.H2O', 'mp.C2H2F4'),
+                    ids=('water', 'R134a'))
+    def subst(self, request):
+        o = pm.get(request.param)
+        return o
+
+    def test_T_only_varg(self, subst):
+        # Based on how .T is written, it interprets this as a temperature given
+        # So just make sure that works
+        assert subst.T(300) == subst.T(T=300, p=pm.config['def_p'])
+
+    def test_T_double_specified(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(300, T=300)
+
+    def test_p_double_specified(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(300, 1, p=1)
+
+    def test_varg_specified(self, subst):
+        assert subst.s(300, 1) == subst.s(p=1, T=300)
+
+    def test_varg_toomany(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(300, 1, 5)
+
+    def test_any_arg_toomany(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(300, 1, s=5)
+        with raises(pm.utility.PMParamError):
+            subst.T(T=300, p=1, s=5)
+
+    def test_default_usage(self, subst):
+        assert subst.s() == subst.s(T=pm.config['def_T'], p=pm.config['def_p'])
+        assert subst.s(T=pm.config['def_T']) == subst.s(T=pm.config['def_T'], p=pm.config['def_p'])
+        assert subst.s(p=pm.config['def_p']) == subst.s(T=pm.config['def_T'], p=pm.config['def_p'])
+        # And for saturated
+        assert subst.ss() == subst.ss(T=pm.config['def_T'])
+        assert subst.Ts() == subst.Ts(p=pm.config['def_p'])
+        assert subst.ps() == subst.ps(T=pm.config['def_T'])
+
+    def test_invarg_toomany(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(h=300, s=5)
+        with raises(pm.utility.PMParamError):
+            subst.T(e=300, s=5)
+
+    def test_d_v_collision(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(d=1, v=1)
+
+    def test_illegal_prop(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(T=300, fakeprop=10000)
+
+    def test_T_oob_all(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(T=30000, p=1)
+
+    def test_T_oob_some(self, subst):
+        vals = subst.T(T=[300, 30000], p=1)
+        assert vals[0] == 300
+        assert np.isnan(vals[1])
+
+    def test_p_oob_all(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(T=300, p=1e100)
+
+    def test_p_oob_some(self, subst):
+        vals = subst.p(T=300, p=[1, 1e100])
+        assert vals[0] == approx(1)
+        assert np.isnan(vals[1])
+
+    def test_x_oob(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.T(p=1, x=2)
+        with raises(pm.utility.PMParamError):
+            subst.T(p=1, x=-2)
+
+    def test_sat_oob_T(self, subst):
+        Tt, pt = subst.triple()
+        Tc, pc = subst.critical()
+        with raises(pm.utility.PMParamError):
+            subst.ps(T=Tt-1)
+        with raises(pm.utility.PMParamError):
+            subst.ps(T=Tc+1)
+        with raises(pm.utility.PMParamError):
+            subst.ds(T=Tt - 1)
+        with raises(pm.utility.PMParamError):
+            subst.ds(T=Tc + 1)
+
+    def test_sat_oob_p(self, subst):
+        Tt, pt = subst.triple()
+        Tc, pc = subst.critical()
+        with raises(pm.utility.PMParamError):
+            subst.Ts(p=pt-1)
+        with raises(pm.utility.PMParamError):
+            subst.Ts(p=pc+1)
+        with raises(pm.utility.PMParamError):
+            subst.ds(p=pt-1)
+        with raises(pm.utility.PMParamError):
+            subst.ds(p=pc+1)
+
+    def test_sat_toomany(self, subst):
+        with raises(pm.utility.PMParamError):
+            subst.ds(T=300, p=1)
+
+
+class TestGeneral:
+
+    @pytest.fixture
+    def water(self):
+        return pm.get('mp.H2O')
+
+    @pytest.mark.parametrize('sub', ('mp.H2O', 'mp.C2H2F4'), ids=('water', 'r134a'))
+    def test_get(self, sub):
+        # Just confirm no error
+        mp1obj = pm.get(sub)
+
+    def test_Tlim(self, water):
+        lim = (273.16, 1273)
+        assert water.Tlim() == approx(lim)
+        assert water.Tlim(p=1) == approx(lim)
+
+    def test_plim(self, water):
+        lim = (0, 10000)
+        assert water.plim() == approx(lim)
+        assert water.plim(T=1000) == approx(lim)
+
+    def test_critical(self, water):
+        cr = (647.096, 220.64, 322.0)
+        assert water.critical() == approx(cr[0:2])
+        assert water.critical(density=True) == approx(cr)
+
+    def test_triple(self, water):
+        tp = (273.16, 0.00611655)
+        assert water.triple() == approx(tp)
+
+    @pytest.mark.parametrize('sub, expect',
+                             [('mp.H2O', 18.015268),
+                              ('mp.C2H2F4', 102.032)])
+    def test_mw(self, sub, expect):
+        assert pm.get(sub).mw() == approx(expect)
+
+    @pytest.mark.parametrize('sub, expect',
+                             [('mp.H2O', pm.units.const_Ru / 18.015268),
+                              ('mp.C2H2F4', pm.units.const_Ru / 102.032)])
+    def test_R(self, sub, expect):
+        assert pm.get(sub).R() == approx(expect)
+
+    @pytest.mark.parametrize('sub, expect', [
+        ('mp.H2O', {'H': 2, 'O': 1}),
+        ('mp.C2H2F4', {'C': 2, 'H': 2, 'F': 4})
+    ])
+    def test_atoms(self, sub, expect):
+        assert pm.get(sub).atoms() == approx(expect)
+
+    @pytest.mark.parametrize('sub, expect', [
+        ('mp.H2O', 4.1813595),
+        ('mp.C2H2F4', 0.85124365)
+    ])
+    def test_cp(self, sub, expect):
+        assert pm.get(sub).cp() == approx(expect)
+        assert pm.get(sub).cp(x=0.5) == approx(np.inf)
+        cp, x = pm.get(sub).cp(quality=True)
+        assert cp == approx(expect)
+
+    @pytest.mark.parametrize('sub, expect, expect05', [
+        ('mp.H2O', 4.13760893, 67.6735),
+        ('mp.C2H2F4', 0.7603562, 3.39377)
+    ])
+    def test_cv(self, sub, expect, expect05):
+        assert pm.get(sub).cv() == approx(expect)
+        assert pm.get(sub).cv(x=0.5) == approx(expect05)
+        cv, x = pm.get(sub).cv(quality=True)
+        assert cv == approx(expect)
+
+    @pytest.mark.parametrize('sub, expect', [
+        ('mp.H2O', 1.01057388),
+        ('mp.C2H2F4', 1.11953272)
+    ])
+    def test_gam(self, sub, expect):
+        assert pm.get(sub).gam() == approx(expect)
+        assert pm.get(sub).gam(x=0.5) == approx(np.inf)
+        gam, x = pm.get(sub).gam(quality=True)
+        assert gam == approx(expect)
+
+
+class TestSat:
+
+    @pytest.fixture
+    def water(self):
+        return pm.get('mp.H2O')
+
+    @pytest.fixture
+    def ref_sat_T(self):  # Some slight deviation from NIST. Keeping both vals listed
+        vals = {'T': 500,  # K
+                'p': 26.392226747183663,  # bar # NIST 26.392
+                'd': (831.35713738, 13.19861192),  # kg/m3  # NIST 831.31, 13.199
+                'v': (0.00120285, 0.07576554),  # m3/kg  # NIST 0.0012029, 0.07564
+                'e': (972.22040467, 2602.55303444),  # kJ/kg # NIST 972.26, 2602.5
+                'h': (975.45086017, 2802.5115447),  # kJ/kg  # NIST 975.43, 2.5810
+                's': (2.58098058, 6.23522113),  # kJ/kg K  # NIST 2.5810, 6.2351
+                }
+        return vals
+
+    @pytest.fixture
+    def ref_sat_p(self):
+        vals = {'T': 424.98,  # K
+                'p': 5.,  # bar
+                'd': (915.29133902, 2.66790101),  # kg/m3  # NIST 915.29, 2.6680
+                'v': (0.00109255, 0.3748265),  # m3/kg  # NIST 0.0010925, 0.37481
+                'e': (639.54607876, 2560.73598375),  # kJ/kg  # NIST 639.54, 2560.7
+                'h': (640.09563612, 2748.14164556),  # kJ/kg  # NIST 640.09, 2748.1
+                's': (1.86040396, 6.82076331),  # kJ/kg K  # NIST 1.8604, 6.8207
+                }
+        return vals
+
+    # ##### Test accuracy to reference saturation data ##### #
+
+    def test_ref_sat_p_Ts(self, water, ref_sat_p):
+        assert water.Ts(p=ref_sat_p['p']) == approx(ref_sat_p['T'], rel=1e-5, abs=1e-2)
+        assert water.Ts(p=np.tile(ref_sat_p['p'], 3)) == approx(
+            np.tile(ref_sat_p['T'], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_p_ds(self, water, ref_sat_p):
+        assert water.ds(p=ref_sat_p['p']) == approx(ref_sat_p['d'], rel=1e-5, abs=1e-2)
+        assert water.ds(p=np.tile(ref_sat_p['p'], 3))[0] == approx(
+            np.tile(ref_sat_p['d'][0], 3), rel=1e-5, abs=1e-2)
+        assert water.ds(p=np.tile(ref_sat_p['p'], 3))[1] == approx(
+            np.tile(ref_sat_p['d'][1], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_p_vs(self, water, ref_sat_p):
+        assert water.vs(p=ref_sat_p['p']) == approx(ref_sat_p['v'], rel=1e-5, abs=1e-2)
+        assert water.vs(p=np.tile(ref_sat_p['p'], 3))[0] == approx(
+            np.tile(ref_sat_p['v'][0], 3), rel=1e-5, abs=1e-2)
+        assert water.vs(p=np.tile(ref_sat_p['p'], 3))[1] == approx(
+            np.tile(ref_sat_p['v'][1], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_p_es(self, water, ref_sat_p):
+        assert water.es(p=ref_sat_p['p']) == approx(ref_sat_p['e'], rel=1e-5, abs=1e-2)
+        assert water.es(p=np.tile(ref_sat_p['p'], 3))[0] == approx(
+            np.tile(ref_sat_p['e'][0], 3), rel=1e-5, abs=1e-2)
+        assert water.es(p=np.tile(ref_sat_p['p'], 3))[1] == approx(
+            np.tile(ref_sat_p['e'][1], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_p_hs(self, water, ref_sat_p):
+        assert water.hs(p=ref_sat_p['p']) == approx(ref_sat_p['h'], rel=1e-5, abs=1e-2)
+        assert water.hs(p=np.tile(ref_sat_p['p'], 3))[0] == approx(
+            np.tile(ref_sat_p['h'][0], 3), rel=1e-5, abs=1e-2)
+        assert water.hs(p=np.tile(ref_sat_p['p'], 3))[1] == approx(
+            np.tile(ref_sat_p['h'][1], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_p_ss(self, water, ref_sat_p):
+        assert water.ss(p=ref_sat_p['p']) == approx(ref_sat_p['s'], rel=1e-5, abs=1e-2)
+        assert water.ss(p=np.tile(ref_sat_p['p'], 3))[0] == approx(
+            np.tile(ref_sat_p['s'][0], 3), rel=1e-5, abs=1e-2)
+        assert water.ss(p=np.tile(ref_sat_p['p'], 3))[1] == approx(
+            np.tile(ref_sat_p['s'][1], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_T_ps(self, water, ref_sat_T):
+        assert water.ps(T=ref_sat_T['T']) == approx(ref_sat_T['p'], rel=1e-5, abs=1e-2)
+        assert water.ps(T=np.tile(ref_sat_T['T'], 3)) == approx(
+            np.tile(ref_sat_T['p'], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_T_ds(self, water, ref_sat_T):
+        assert water.ds(T=ref_sat_T['T']) == approx(ref_sat_T['d'], rel=1e-5, abs=1e-2)
+        assert water.ds(T=np.tile(ref_sat_T['T'], 3))[0] == approx(
+            np.tile(ref_sat_T['d'][0], 3), rel=1e-5, abs=1e-2)
+        assert water.ds(T=np.tile(ref_sat_T['T'], 3))[1] == approx(
+            np.tile(ref_sat_T['d'][1], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_T_es(self, water, ref_sat_T):
+        assert water.es(T=ref_sat_T['T']) == approx(ref_sat_T['e'], rel=1e-5, abs=1e-2)
+        assert water.es(T=np.tile(ref_sat_T['T'], 3))[0] == approx(
+            np.tile(ref_sat_T['e'][0], 3), rel=1e-5, abs=1e-2)
+        assert water.es(T=np.tile(ref_sat_T['T'], 3))[1] == approx(
+            np.tile(ref_sat_T['e'][1], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_T_hs(self, water, ref_sat_T):
+        assert water.hs(T=ref_sat_T['T']) == approx(ref_sat_T['h'], rel=1e-5, abs=1e-2)
+        assert water.hs(T=np.tile(ref_sat_T['T'], 3))[0] == approx(
+            np.tile(ref_sat_T['h'][0], 3), rel=1e-5, abs=1e-2)
+        assert water.hs(T=np.tile(ref_sat_T['T'], 3))[1] == approx(
+            np.tile(ref_sat_T['h'][1], 3), rel=1e-5, abs=1e-2)
+
+    def test_ref_sat_T_ss(self, water, ref_sat_T):
+        assert water.ss(T=ref_sat_T['T']) == approx(ref_sat_T['s'], rel=1e-5, abs=1e-2)
+        assert water.ss(T=np.tile(ref_sat_T['T'], 3))[0] == approx(
+            np.tile(ref_sat_T['s'][0], 3), rel=1e-5, abs=1e-2)
+        assert water.ss(T=np.tile(ref_sat_T['T'], 3))[1] == approx(
+            np.tile(ref_sat_T['s'][1], 3), rel=1e-5, abs=1e-2)
+
+
+def make_props_array(refs, subid):
+    """
+    Take a property array formatted like refs{}
+    """
+    propkeys = None
+    myrefs = []
+
+    # Find which ref states match this substance
+    for refkey in refs:
+        if refs[refkey]['sub'] == subid:
+            myrefs.append(refs[refkey])
+            if propkeys is None:
+                propkeys = refs[refkey]['props']
+
+    # Build a new dict from the refs
+    newdict= {
+        'props': {
+            key: [ref['props'][key] for ref in myrefs] for key in propkeys
+        },
+        'sub': subid,
+        'comment': 'multi'
+    }
+    return newdict
+
+
+# Four reference points for H2O (NIST Webbook), and two saturation states
+# Note that spec volumes are computed as 1/d for accuracy. NIST vals listed.
+refs = {}
+refs["water_a"] = {
+    'props': {
+        # values generated by pyromat using T&p. Checks with NIST
+        'T': 300,  # K
+        'p': 5,  # bar
+        'd': 996.73584742,  # kg/m3
+        'v': 1/996.73584742,  # m3/kg
+        'e': 112.5214752,  # kJ/kg
+        'h': 113.02311262,  # kJ/kg
+        's': 0.39295625,  # kJ/kg K
+        'x': -1,
+    },
+    'NIST': {
+        'T': 300,  # K
+        'p': 5,  # bar
+        'd': 996.74,  # kg/m3
+        'v': 0.0010033,  # m3/kg
+        'e': 112.52,  # kJ/kg
+        'h': 113.02,  # kJ/kg
+        's': 0.39295,  # kJ/kg K
+        'x': -1,
+    },
+    'sub': 'mp.H2O',
+    'comment': 'compressed liquid'
+}
+refs["water_b"] = {
+    'props': {
+        # values generated by pyromat using T&p. Checks with NIST
+        'T': 600,  # K
+        'p': 5,  # bar
+        'd': 1.82413427,  # kg/m3
+        'v': 1/1.82413427,  # m3/kg
+        'e': 2846.01833204,  # kJ/kg
+        'h': 3120.12094234,  # kJ/kg
+        's': 7.55619253,  # kJ/kg K
+        'x': -1,
+    },
+    'NIST': {
+        'T': 600,  # K
+        'p': 5,  # bar
+        'd': 1.8242,  # kg/m3
+        'v': 0.54820,  # m3/kg
+        'e': 2846.0,  # kJ/kg
+        'h': 3120.1,  # kJ/kg
+        's': 7.5561,  # kJ/kg K
+        'x': -1,
+    },
+    'sub': 'mp.H2O',
+    'comment': 'superheated vapor'
+}
+refs["water_c"] = {
+    'props': {
+        # values generated by pyromat using p&x. Checks with NIST
+        'T': 424.98151125,  # K
+        'p': 5,  # bar
+        'd': 5.32029437,  # kg/m3
+        'v': 1/5.32029437,  # m3/kg
+        'e': 1600.14103126,  # kJ/kg
+        'h': 1694.11864084,  # kJ/kg
+        's': 4.34058363,  # kJ/kg K
+        'x': 0.5,
+    },
+    'NIST': {
+        'T': 424.98,  # K
+        'p': 5,  # bar
+        'd': 5.321,  # kg/m3
+        'v': 0.18795,  # m3/kg
+        'e': 1600.12,  # kJ/kg
+        'h': 1694.095,  # kJ/kg
+        's': 4.3406,  # kJ/kg K
+        'x': 0.5,
+    },
+    'sub': 'mp.H2O',
+    'comment': 'saturated mixture'
+}
+refs["water_d"] = {
+    'props': {
+        # values generated by pyromat using p&x. Checks with NIST
+        'T': 800,  # K
+        'p': 250,  # bar
+        'd': 83.13115268,  # kg/m3
+        'v': 1/83.13115268,  # m3/kg
+        'e': 2961.48937738,  # kJ/kg
+        'h': 3262.21899789,  # kJ/kg
+        's': 6.08676043,  # kJ/kg K
+        'x': -1,
+    },
+    'NIST': {
+        'T': 800,  # K
+        'p': 250,  # bar
+        'd': 83.132,  # kg/m3
+        'v': 0.012029,  # m3/kg
+        'e': 2961.5,  # kJ/kg
+        'h': 3262.2,  # kJ/kg
+        's': 6.0867,  # kJ/kg K
+        'x': -1,
+    },
+    'sub': 'mp.H2O',
+    'comment': 'supercritical fluid'
+}
+refs['water_array'] = make_props_array(refs, 'mp.H2O')
+
+refs["r134a_a"] = {
+    'props': {
+        # values generated by pyromat using T&p. Checks with NIST
+        'T': 200,  # K
+        'p': 5,  # bar
+        'd': 1511.25811875,  # kg/m3
+        'v': 1/1511.25811875,  # m3/kg
+        'e': 107.27245971,  # kJ/kg
+        'h': 107.60330988,  # kJ/kg
+        's': 0.606735,  # kJ/kg K
+        'x': -1,
+    },
+    'NIST': {
+        'T': 300,  # K
+        'p': 5,  # bar
+        'd': 1511.3,  # kg/m3
+        'v': 0.00066170	,  # m3/kg
+        'e': 107.27,  # kJ/kg
+        'h': 107.60,  # kJ/kg
+        's': 0.60674,  # kJ/kg K
+        'x': -1,
+    },
+    'sub': 'mp.C2H2F4',
+    'comment': 'compressed liquid'
+}
+
+refs["r134a_b"] = {
+    'props': {
+        # values generated by pyromat using T&p. Checks with NIST
+        'T': 300,  # K
+        'p': 5,  # bar
+        'd': 22.90875049,  # kg/m3
+        'v': 1/22.90875049,  # m3/kg
+        'e': 396.33598821,  # kJ/kg
+        'h': 418.16170929,  # kJ/kg
+        's': 1.75600437,  # kJ/kg K
+        'x': -1,
+    },
+    'NIST': {
+        'T': 300,  # K
+        'p': 5,  # bar
+        'd': 22.909,  # kg/m3
+        'v': 0.043651,  # m3/kg
+        'e': 396.34,  # kJ/kg
+        'h': 418.16,  # kJ/kg
+        's': 1.7560,  # kJ/kg K
+        'x': -1,
+    },
+    'sub': 'mp.C2H2F4',
+    'comment': 'superheated vapor'
+}
+
+refs["r134a_c"] = {
+    'props': {
+        # values generated by pyromat using p&x. Checks with NIST
+        'T': 288.8850165,  # K
+        'p': 5,  # bar
+        'd': 47.67918444,  # kg/m3
+        'v': 1/47.67918444,  # m3/kg
+        'e': 303.99268139,  # kJ/kg
+        'h': 314.49195319,  # kJ/kg
+        's': 1.3977908,  # kJ/kg K
+        'x': 0.5,
+    },
+    'NIST': {
+        'T': 288.88,  # K
+        'p': 5,  # bar
+        'd': 47.700,  # kg/m3
+        'v': 0.020964,  # m3/kg
+        'e': 304.01,  # kJ/kg
+        'h': 314.49,  # kJ/kg
+        's': 1.3978,  # kJ/kg K
+        'x': 0.5,
+    },
+    'sub': 'mp.C2H2F4',
+    'comment': 'saturated mixture'
+}
+
+refs["r134a_d"] = {
+    'props': {
+        # values generated by pyromat using T&p. Checks with NIST
+        'T': 400,  # K
+        'p': 50,  # bar
+        'd': 285.05284058,  # kg/m3
+        'v': 1/285.05284058,  # m3/kg
+        'e': 439.61684889,  # kJ/kg
+        'h': 457.15745307,  # kJ/kg
+        's': 1.7310427,  # kJ/kg K
+        'x': -1,
+    },
+    'NIST': {
+        'T': 400,  # K
+        'p': 50,  # bar
+        'd': 285.05,  # kg/m3
+        'v': 0.0035081,  # m3/kg
+        'e': 439.62,  # kJ/kg
+        'h': 457.16,  # kJ/kg
+        's': 1.7310,  # kJ/kg K
+        'x': -1,
+    },
+    'sub': 'mp.C2H2F4',
+    'comment': 'supercritical'
+}
+
+refs['r134a_array'] = make_props_array(refs, 'mp.C2H2F4')
+
+
+class TestRefs:
+
+    @pytest.fixture(params=(refs[key] for key in refs), ids=(refs.keys()))
+    def refdat(self, request):
+        return {'sub': pm.get(request.param['sub']),
+                'data': request.param['props']}
+
+    @pytest.fixture(params=('p', 'T', 'd', 'v', 'e', 'h', 's', 'x'))
+    def param(self, request):
+        return request.param
+
+    def test_pT(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        if (np.array(ref['x']) > 0).any():
+            pass
+        else:
+            assert fn(p=ref['p'], T=ref['T']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_pTx(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], T=ref['T'], x=ref['x']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_pd(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], d=ref['d']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_pd_qualityflag(self, param, refdat):
+        if param == 'x':
+            pass  # quality flag not supported for substance.x()
+        else:
+            sub, ref = refdat['sub'], refdat['data']
+            fn = getattr(sub, param)
+            parval, x = fn(p=ref['p'], d=ref['d'], quality=True)
+            assert parval == approx(ref[param], rel=1e-5, abs=1e-2)
+            assert x == approx(ref['x'], rel=1e-5, abs=1e-2)
+
+    def test_pv(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], v=ref['v']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_Td(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(T=ref['T'], d=ref['d']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_Tv(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(T=ref['T'], v=ref['v']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_ps(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], s=ref['s']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_Ts(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(T=ref['T'], s=ref['s']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_ds(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(d=ref['d'], s=ref['s']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_vs(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(v=ref['v'], s=ref['s']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_ph(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], h=ref['h']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    @pytest.mark.skip(reason="T&h and T&e aren't viable combos for most cases")
+    def test_Th(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMAnalysisError):
+            assert fn(T=ref['T'], h=ref['h']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_dh(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(d=ref['d'], h=ref['h']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_vh(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(v=ref['v'], h=ref['h']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_pe(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(p=ref['p'], e=ref['e']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    @pytest.mark.skip(reason="T&h and T&e aren't viable combos for most cases")
+    def test_Te(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMAnalysisError):
+            assert fn(T=ref['T'], e=ref['e']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_de(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(d=ref['d'], e=ref['e']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_ve(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        assert fn(v=ref['v'], e=ref['e']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_px(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        if (np.array(ref['x']) < 0).any():
+            # Illegal
+            with raises(pm.utility.PMParamError):
+                fn(p=ref['p'], x=ref['x'])
+        else:
+            assert fn(p=ref['p'], x=ref['x']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    def test_Tx(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        if (np.array(ref['x']) < 0).any():
+            # Illegal
+            with raises(pm.utility.PMParamError):
+                fn(T=ref['T'], x=ref['x'])
+        else:
+            assert fn(T=ref['T'], x=ref['x']) == approx(ref[param], rel=1e-5, abs=1e-2)
+
+    # Always Unsupported Cases
+    def test_dv(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            assert fn(d=ref['d'], v=ref['v'])
+
+    def test_hs(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            assert fn(h=ref['h'], s=ref['s'])
+
+    def test_es(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            assert fn(e=ref['e'], s=ref['s'])
+
+    def test_he(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            assert fn(h=ref['h'], e=ref['e'])
+
+    def test_hx(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            assert fn(h=ref['h'], x=ref['x'])
+
+    def test_ex(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            assert fn(e=ref['e'], x=ref['x'])
+
+    def test_sx(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        with raises(pm.utility.PMParamError):
+            assert fn(s=ref['s'], x=ref['x'])
+
+    def test_dx(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        if (np.array(ref['x']) < 0).any():
+            # Illegal
+            with raises(pm.utility.PMParamError):
+                fn(d=ref['d'], x=ref['x'])
+        else:
+            # Legal but not supported
+            with raises(pm.utility.PMParamError):
+                fn(d=ref['d'], x=ref['x'])
+
+    def test_vx(self, param, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        fn = getattr(sub, param)
+        if (np.array(ref['x']) < 0).any():
+            # Illegal
+            with raises(pm.utility.PMParamError):
+                fn(v=ref['v'], x=ref['x'])
+        else:
+            # Legal but not supported
+            with raises(pm.utility.PMParamError):
+                fn(d=ref['d'], x=ref['x'])
+
+    # Legacy deprecated items
+    def test_hsd(self, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        h, s, d = sub.hsd(T=ref['T'], p=ref['p'], x=ref['x'])
+        assert h == approx(ref['h'], rel=1e-5, abs=1e-2)
+        assert s == approx(ref['s'], rel=1e-5, abs=1e-2)
+        assert d == approx(ref['d'], rel=1e-5, abs=1e-2)
+        h, s, d, x = sub.hsd(T=ref['T'], p=ref['p'], x=ref['x'], quality=True)
+        assert h == approx(ref['h'], rel=1e-5, abs=1e-2)
+        assert s == approx(ref['s'], rel=1e-5, abs=1e-2)
+        assert d == approx(ref['d'], rel=1e-5, abs=1e-2)
+        assert x == approx(ref['x'], rel=1e-5, abs=1e-2)
+
+    def test_T_s(self, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        assert sub.T_s(s=ref['s'], p=ref['p']) == approx(ref['T'], rel=1e-5, abs=1e-2)
+        T, x = sub.T_s(s=ref['s'], p=ref['p'], quality=True)
+        assert T == approx(ref['T'], rel=1e-5, abs=1e-2)
+        assert x == approx(ref['x'], rel=1e-5, abs=1e-2)
+
+    def test_d_s(self, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        assert sub.d_s(s=ref['s'], p=ref['p']) == approx(ref['d'], rel=1e-5, abs=1e-2)
+        d, x = sub.d_s(s=ref['s'], p=ref['p'], quality=True)
+        assert d == approx(ref['d'], rel=1e-5, abs=1e-2)
+        assert x == approx(ref['x'], rel=1e-5, abs=1e-2)
+
+    def test_T_h(self, refdat):
+        sub, ref = refdat['sub'], refdat['data']
+        assert sub.T_h(h=ref['h'], p=ref['p']) == approx(ref['T'], rel=1e-5, abs=1e-2)
+        T, x = sub.T_h(h=ref['h'], p=ref['p'], quality=True)
+        assert T == approx(ref['T'], rel=1e-5, abs=1e-2)
+        assert x == approx(ref['x'], rel=1e-5, abs=1e-2)
+
+
+class TestState:
+
+    @pytest.fixture(params=(refs[key] for key in refs), ids=(refs.keys()))
+    def refdat(self, request):
+        return {'sub': pm.get(request.param['sub']),
+                'data': request.param['props']}
+
+    @pytest.fixture(params=('p', 'T', 'd', 'v', 'e', 'h', 's', 'x'))
+    def prop(self, request):
+        return request.param
+
+    def test_state_pTx(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(T=ref['T'], p=ref['p'], x=ref['x'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_pd(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], d=ref['d'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_pv(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], v=ref['v'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_Td(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(T=ref['T'], d=ref['d'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_Tv(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(T=ref['T'], v=ref['v'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_ps(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], s=ref['s'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_Ts(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(T=ref['T'], s=ref['s'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_ds(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(d=ref['d'], s=ref['s'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_vs(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(v=ref['v'], s=ref['s'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_ph(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], h=ref['h'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    @pytest.mark.skip(reason="T&h and T&e aren't viable combos for most cases")
+    def test_state_Th(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        with raises(pm.utility.PMAnalysisError):
+            state = sub.state(T=ref['T'], h=ref['h'])
+
+    def test_state_dh(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(d=ref['d'], h=ref['h'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_vh(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(v=ref['v'], h=ref['h'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_pe(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(p=ref['p'], e=ref['e'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    @pytest.mark.skip(reason="T&h and T&e aren't viable combos for most cases")
+    def test_state_Te(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        with raises(pm.utility.PMAnalysisError):
+            state = sub.state(T=ref['T'], e=ref['e'])
+
+    def test_state_de(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(d=ref['d'], e=ref['e'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)
+
+    def test_state_ve(self, refdat, prop):
+        sub, ref = refdat['sub'], refdat['data']
+        state = sub.state(v=ref['v'], e=ref['e'])
+        assert state[prop] == approx(ref[prop], rel=1e-5, abs=1e-2)


### PR DESCRIPTION
Per the request for the JOSS paper that we add tests to the main branch, here are those two straightforward test files along with a Github Workflow to run them on commits to the master branch. I tested this out in the side branch and it appears to work.