### PR TITLE
Add extras_require config for pytest in dev mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,6 @@ setuptools.setup(
     package_data={'pyromat':['config.py', 'data/mp/*.hpd', 'data/ig/*.hpd','data/ig2/*.hpd','data/igmix/*.hpd','registry/*.py','aps/*.py']},
     license_files=['LICENSE.txt'],
     install_requires=['numpy>=1.7'],
+    extras_require={'dev': ['pytest']},
     provides=['pyromat']
     )


### PR DESCRIPTION
Add an option for different sets of dependencies with `python setup.py` calls, in this case `pytest`, only if you specify the `dev` flag. It make sense in that those dependencies aren't necessary for people who wish to just use the code. 

Closes #66 