### PR TITLE
Remove legacy tests. Add test_units to github workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,6 @@ jobs:
     - name: Test Multiphase
       working-directory: ./src/test
       run: pytest test_mp1.py
+    - name: Test Unit Conversion
+      working-directory: ./src/test
+      run: pytest test_units.py

--- a/src/test/test_ig.py
+++ b/src/test/test_ig.py
@@ -454,19 +454,6 @@ class TestRefs:
         with raises(pm.utility.PMParamError):
             fn(h=ref['h'], e=ref['e'])
 
-    # Legacy (deprecated) functions
-    def test_T_s(self, refdat):
-        sub, ref = refdat['sub'], refdat['data']
-        assert sub.T_s(s=ref['s'], p=ref['p']) == approx(ref['T'], rel=1e-5, abs=1e-1)
-
-    def test_T_h(self, refdat):
-        sub, ref = refdat['sub'], refdat['data']
-        assert sub.T_h(h=ref['h']) == approx(ref['T'], rel=1e-5, abs=1e-1)
-
-    def test_p_s(self, refdat):
-        sub, ref = refdat['sub'], refdat['data']
-        assert sub.p_s(s=ref['s'], T=ref['T']) == approx(ref['p'], rel=1e-5, abs=1e-1)
-
 
 class TestState:
 

--- a/src/test/test_mp1.py
+++ b/src/test/test_mp1.py
@@ -741,40 +741,6 @@ class TestRefs:
             with raises(pm.utility.PMParamError):
                 fn(d=ref['d'], x=ref['x'])
 
-    # Legacy deprecated items
-    def test_hsd(self, refdat):
-        sub, ref = refdat['sub'], refdat['data']
-        h, s, d = sub.hsd(T=ref['T'], p=ref['p'], x=ref['x'])
-        assert h == approx(ref['h'], rel=1e-5, abs=1e-2)
-        assert s == approx(ref['s'], rel=1e-5, abs=1e-2)
-        assert d == approx(ref['d'], rel=1e-5, abs=1e-2)
-        h, s, d, x = sub.hsd(T=ref['T'], p=ref['p'], x=ref['x'], quality=True)
-        assert h == approx(ref['h'], rel=1e-5, abs=1e-2)
-        assert s == approx(ref['s'], rel=1e-5, abs=1e-2)
-        assert d == approx(ref['d'], rel=1e-5, abs=1e-2)
-        assert x == approx(ref['x'], rel=1e-5, abs=1e-2)
-
-    def test_T_s(self, refdat):
-        sub, ref = refdat['sub'], refdat['data']
-        assert sub.T_s(s=ref['s'], p=ref['p']) == approx(ref['T'], rel=1e-5, abs=1e-2)
-        T, x = sub.T_s(s=ref['s'], p=ref['p'], quality=True)
-        assert T == approx(ref['T'], rel=1e-5, abs=1e-2)
-        assert x == approx(ref['x'], rel=1e-5, abs=1e-2)
-
-    def test_d_s(self, refdat):
-        sub, ref = refdat['sub'], refdat['data']
-        assert sub.d_s(s=ref['s'], p=ref['p']) == approx(ref['d'], rel=1e-5, abs=1e-2)
-        d, x = sub.d_s(s=ref['s'], p=ref['p'], quality=True)
-        assert d == approx(ref['d'], rel=1e-5, abs=1e-2)
-        assert x == approx(ref['x'], rel=1e-5, abs=1e-2)
-
-    def test_T_h(self, refdat):
-        sub, ref = refdat['sub'], refdat['data']
-        assert sub.T_h(h=ref['h'], p=ref['p']) == approx(ref['T'], rel=1e-5, abs=1e-2)
-        T, x = sub.T_h(h=ref['h'], p=ref['p'], quality=True)
-        assert T == approx(ref['T'], rel=1e-5, abs=1e-2)
-        assert x == approx(ref['x'], rel=1e-5, abs=1e-2)
-
 
 class TestState:
 


### PR DESCRIPTION
This removes legacy tests from test_mp1.py and test_ig.py. Both passed on my local machine. 

While I was at it, I added the units test code to the Github workflow.

Closes #69 